### PR TITLE
Change ExprFunctionProperty to use 'of' instead of 'from'

### DIFF
--- a/src/main/java/org/byteskript/skript/lang/syntax/entry/syntax/EntrySyntaxProperty.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/entry/syntax/EntrySyntaxProperty.java
@@ -26,7 +26,7 @@ import org.byteskript.skript.lang.element.StandardElements;
                 syntax:
                     property: name
                 trigger:
-                    run set_name({name}) from {thing}
+                    run set_name({name}) of {thing}
             """
     }
 )

--- a/src/main/java/org/byteskript/skript/lang/syntax/function/ExprFunctionProperty.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/function/ExprFunctionProperty.java
@@ -26,21 +26,21 @@ import java.util.regex.Matcher;
         """,
     examples = {
         """
-            set {sides} to get_sides() from {square}
+            set {sides} to get_sides() of {square}
                 """
     }
 )
 public class ExprFunctionProperty extends SimpleExpression {
     
-    private static final java.util.regex.Pattern PATTERN = java.util.regex.Pattern.compile("(?<name>" + SkriptLangSpec.IDENTIFIER.pattern() + ")\\((?<params>.*)\\) from (?<object>.+)");
+    private static final java.util.regex.Pattern PATTERN = java.util.regex.Pattern.compile("(?<name>" + SkriptLangSpec.IDENTIFIER.pattern() + ")\\((?<params>.*)\\) of (?<object>.+)");
     
     public ExprFunctionProperty() {
-        super(SkriptLangSpec.LIBRARY, StandardElements.EXPRESSION, "function(...) from %Object%");
+        super(SkriptLangSpec.LIBRARY, StandardElements.EXPRESSION, "function(...) of %Object%");
     }
     
     @Override
     public Pattern.Match match(String thing, Context context) {
-        if (!thing.contains(") from ")) return null;
+        if (!thing.contains(") of ")) return null;
         if (!thing.contains("(")) return null;
         return createMatch(thing, context);
     }
@@ -93,7 +93,7 @@ public class ExprFunctionProperty extends SimpleExpression {
                 builder.append("(.+)");
             }
         }
-        return builder.append("\\) from (.+)").toString();
+        return builder.append("\\) of (.+)").toString();
     }
     
     @Override

--- a/src/test/resources/tests/properties.bsk
+++ b/src/test/resources/tests/properties.bsk
@@ -25,7 +25,7 @@ function simple_example: // todo - check other property accessors inside types
         set age of {thing} to 62
         assert name of {thing} is "Thing": "Name property set/access failed."
         assert age of {thing} is 62: "Age property set/access failed."
-        run set_house("hello") from {thing}
+        run set_house("hello") of {thing}
         assert house of {thing} is "hello": "Local set failed."
 
 type Thing:
@@ -62,6 +62,6 @@ function test:
         assert {error} exists: "Error was not thrown during illegal set."
         delete {error}
         assert blob of {thing} is null: "Empty field was set somehow."
-        assert blob() from {thing} is "hello": "Function access failed."
+        assert blob() of {thing} is "hello": "Function access failed."
         run simple_example()
         return true

--- a/src/test/resources/tests/propertyfunction.bsk
+++ b/src/test/resources/tests/propertyfunction.bsk
@@ -10,7 +10,7 @@ function test:
         set {var} to a new blob
         assert {var} exists
         assert {var} is a blob
-        assert test() from {var} is "hello"
-        set {x} to test() from {var}
+        assert test() of {var} is "hello"
+        set {x} to test() of {var}
         assert {x} is "hello"
         return true

--- a/src/test/resources/tests/templatetype.bsk
+++ b/src/test/resources/tests/templatetype.bsk
@@ -18,9 +18,9 @@ function test:
         set {bar} to a new bar
         assert {bar} is a bar
         assert {bar} is a foo
-        assert box() from {bar} is 3
+        assert box() of {bar} is 3
         set {cee} to a new cee
         assert {cee} is a cee
         assert {cee} is a foo
-        assert box() from {cee} is 2
+        assert box() of {cee} is 2
         return true

--- a/src/test/resources/tests/trigger.bsk
+++ b/src/test/resources/tests/trigger.bsk
@@ -12,6 +12,6 @@ function test:
     trigger:
         set {var} to a new Box
         assert {var} is a Box
-        assert bean() from {var} is "hello"
+        assert bean() of {var} is "hello"
         assert bean() is "there"
         return true

--- a/src/test/resources/tests/typecreator.bsk
+++ b/src/test/resources/tests/typecreator.bsk
@@ -8,5 +8,5 @@ function test:
     trigger:
         set {foo} to a new foo
         assert {foo} is a foo
-        assert box() from {foo} is 2
+        assert box() of {foo} is 2
         return true

--- a/src/test/resources/tests/typemember.bsk
+++ b/src/test/resources/tests/typemember.bsk
@@ -12,7 +12,7 @@ type Box:
     function bonk:
         return: Boolean
         trigger:
-            set {var} to my_func() from this object
+            set {var} to my_func() of this object
             assert {var} is "hello": "Member-local function didn't return properly."
             return true
     function my_func:
@@ -38,13 +38,13 @@ function basic_use:
         assert {thing} is a Box: "Type self-comparison failed."
         assert {thing} is a Thing: "Type template-comparison failed."
         assert "" + {thing} is "Hello?": "Type toString override failed."
-        set {word} to my_func() from {thing}
+        set {word} to my_func() of {thing}
         assert {word} is "hello": "Member function call failed."
-        set {number} to func_with_args(3) from {thing}
+        set {number} to func_with_args(3) of {thing}
         assert {number} is 211: "Member function call with args failed."
-        set {boolean} to bonk() from {thing}
+        set {boolean} to bonk() of {thing}
         assert {boolean} is true: "Member function didn't return correctly."
-        assert another_func() from {thing} is 10: "Template default function didn't return correctly."
+        assert another_func() of {thing} is 10: "Template default function didn't return correctly."
         set {thing} to a new Crate
         assert {thing} exists: "Type creation failed."
         assert {thing} is a Crate: "Type self-comparison failed."
@@ -78,8 +78,8 @@ function multiple_inheritance:
         assert {rectangle} is a Rectangle: "Type self-comparison failed."
         assert {rectangle} is a Quadrilateral: "Type super-comparison failed."
         assert {rectangle} is a Shape: "Type inherited super-comparison failed."
-        assert get_sides() from {square} is 4: "Type default function failed."
-        assert get_sides() from {rectangle} is 4: "Type default function failed."
+        assert get_sides() of {square} is 4: "Type default function failed."
+        assert get_sides() of {rectangle} is 4: "Type default function failed."
 
 type Getter:
     template: java/util/function/Supplier
@@ -93,7 +93,7 @@ function java_implement:
         assert {getter} is a Getter: "Type self-comparison failed."
         set {class} to java/util/function/Supplier
         assert {getter} is a {class}: "Type java super-comparison failed."
-        set {var} to get() from {getter}
+        set {var} to get() of {getter}
         assert {var} is "hello": "Supplier get method failed."
         set {var} to result of {getter}
         assert {var} is "hello": "Supplier result-of failed."
@@ -129,7 +129,7 @@ function test:
         set {foo} to a new bar
         assert {foo} is a foo
         assert {foo} is a bar
-        assert box() from {foo} is 3
+        assert box() of {foo} is 3
         run runnable()
         run basic_use()
         run java_implement()


### PR DESCRIPTION
Changes ExprFunctionProperty to use 'of' instead of 'from' to avoid conflict with ExprFunctionExternal.

Closes #6.