### PR TITLE
Fix all the things

### DIFF
--- a/src/main/java/org/byteskript/skript/api/SyntaxElement.java
+++ b/src/main/java/org/byteskript/skript/api/SyntaxElement.java
@@ -82,9 +82,7 @@ public interface SyntaxElement {
     boolean hasHandler(HandlerType type);
     
     @Description("The return type of this element, used for type tracking during compilation.")
-    default Type getReturnType() {
-        return CommonTypes.VOID;
-    }
+    Type getReturnType();
     
     @Description("""
         This is called during the first compiler pass, Out->In, L->R.
@@ -109,12 +107,12 @@ public interface SyntaxElement {
     default boolean isDelay() {
         return false;
     }
-    
-    @Ignore
+
+    /*@Ignore //TODO: implement requiresMainThread
     default boolean requiresMainThread() {
         return false;
-    }
-    
+    }*/
+
     @Ignore
     default void addSkipInstruction(Context context, Consumer<Context> consumer) {
         context.addSkipInstruction(consumer);

--- a/src/main/java/org/byteskript/skript/api/automatic/GeneratedEntryNode.java
+++ b/src/main/java/org/byteskript/skript/api/automatic/GeneratedEntryNode.java
@@ -6,14 +6,12 @@
 
 package org.byteskript.skript.api.automatic;
 
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.Library;
 import org.byteskript.skript.api.syntax.Element;
 import org.byteskript.skript.api.syntax.Literal;
-import org.byteskript.skript.compiler.CompileState;
-import org.byteskript.skript.compiler.Context;
-import org.byteskript.skript.compiler.ElementTree;
-import org.byteskript.skript.compiler.Pattern;
+import org.byteskript.skript.compiler.*;
 import org.byteskript.skript.error.ScriptParseError;
 import org.byteskript.skript.lang.element.StandardElements;
 
@@ -27,7 +25,12 @@ public class GeneratedEntryNode extends Element {
         super(provider, StandardElements.NODE, patterns);
         this.target = target;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void preCompile(Context context, Pattern.Match match) throws Throwable {
         final ElementTree tree = context.getCompileCurrent().nested()[0];

--- a/src/main/java/org/byteskript/skript/api/automatic/GeneratedEntrySection.java
+++ b/src/main/java/org/byteskript/skript/api/automatic/GeneratedEntrySection.java
@@ -6,9 +6,11 @@
 
 package org.byteskript.skript.api.automatic;
 
+import mx.kenzie.foundation.Type;
 import org.byteskript.skript.api.FunctionalEntrySection;
 import org.byteskript.skript.api.Library;
 import org.byteskript.skript.api.syntax.Section;
+import org.byteskript.skript.compiler.CommonTypes;
 import org.byteskript.skript.compiler.CompileState;
 import org.byteskript.skript.compiler.Context;
 import org.byteskript.skript.compiler.Pattern;
@@ -28,7 +30,12 @@ public final class GeneratedEntrySection extends Section {
         super(provider, StandardElements.SECTION, patterns);
         this.target = target;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void compile(Context context, Pattern.Match match) throws Throwable {
         context.setState(CompileState.AREA_BODY);

--- a/src/main/java/org/byteskript/skript/api/syntax/Effect.java
+++ b/src/main/java/org/byteskript/skript/api/syntax/Effect.java
@@ -13,6 +13,7 @@ import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.LanguageElement;
 import org.byteskript.skript.api.Library;
 import org.byteskript.skript.api.SyntaxElement;
+import org.byteskript.skript.compiler.CommonTypes;
 import org.byteskript.skript.compiler.CompileState;
 import org.byteskript.skript.compiler.Context;
 import org.byteskript.skript.compiler.Pattern;
@@ -25,7 +26,12 @@ public abstract class Effect extends Element implements SyntaxElement {
     public Effect(final Library provider, final LanguageElement type, final String... patterns) {
         super(provider, type, patterns);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public CompileState getSubState() {
         return CompileState.STATEMENT; // looking for expressions here

--- a/src/main/java/org/byteskript/skript/api/syntax/Member.java
+++ b/src/main/java/org/byteskript/skript/api/syntax/Member.java
@@ -9,6 +9,7 @@ package org.byteskript.skript.api.syntax;
 import mx.kenzie.foundation.Type;
 import org.byteskript.skript.api.LanguageElement;
 import org.byteskript.skript.api.Library;
+import org.byteskript.skript.compiler.CommonTypes;
 import org.byteskript.skript.compiler.CompileState;
 import org.byteskript.skript.compiler.Context;
 import org.byteskript.skript.compiler.structure.SectionMeta;
@@ -30,7 +31,12 @@ public abstract class Member extends Section {
         context.setField(null);
         context.setState(CompileState.ROOT);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public boolean allowAsInputFor(Type type) {
         return false;

--- a/src/main/java/org/byteskript/skript/api/syntax/SectionEntry.java
+++ b/src/main/java/org/byteskript/skript/api/syntax/SectionEntry.java
@@ -6,9 +6,11 @@
 
 package org.byteskript.skript.api.syntax;
 
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.LanguageElement;
 import org.byteskript.skript.api.Library;
+import org.byteskript.skript.compiler.CommonTypes;
 import org.byteskript.skript.compiler.CompileState;
 import org.byteskript.skript.compiler.Context;
 
@@ -21,7 +23,12 @@ public abstract class SectionEntry extends Section {
     public CompileState getSubState() {
         return CompileState.MEMBER_BODY;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public boolean allowedIn(State state, Context context) {
         return state == CompileState.MEMBER_BODY;

--- a/src/main/java/org/byteskript/skript/api/syntax/SimpleEntry.java
+++ b/src/main/java/org/byteskript/skript/api/syntax/SimpleEntry.java
@@ -10,6 +10,7 @@ import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.LanguageElement;
 import org.byteskript.skript.api.Library;
+import org.byteskript.skript.compiler.CommonTypes;
 import org.byteskript.skript.compiler.CompileState;
 import org.byteskript.skript.compiler.Context;
 import org.byteskript.skript.compiler.Pattern;
@@ -28,7 +29,12 @@ public abstract class SimpleEntry extends Element {
     public CompileState getSubState() {
         return CompileState.MEMBER_BODY;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public boolean allowAsInputFor(Type type) {
         return false;

--- a/src/main/java/org/byteskript/skript/lang/syntax/config/ExprKeyInConfig.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/config/ExprKeyInConfig.java
@@ -71,6 +71,11 @@ public class ExprKeyInConfig extends RelationalExpression implements Referent {
     public boolean allowAsInputFor(Type type) {
         return super.allowAsInputFor(type) || CommonTypes.REFERENT.equals(type);
     }
-    
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.OBJECT;
+    }
+
+
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/entry/EntryExtends.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/entry/EntryExtends.java
@@ -59,7 +59,12 @@ public class EntryExtends extends SimpleEntry {
     public boolean allowAsInputFor(Type type) {
         return false;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public boolean allowedIn(State state, Context context) {
         return context.getState() == CompileState.ROOT && context.hasFlag(AreaFlag.IN_TYPE);

--- a/src/main/java/org/byteskript/skript/lang/syntax/entry/EntryReturn.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/entry/EntryReturn.java
@@ -60,7 +60,12 @@ public class EntryReturn extends SimpleEntry {
     public boolean allowAsInputFor(Type type) {
         return false;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public boolean allowedIn(State state, Context context) {
         return super.allowedIn(state, context) && context.hasFlag(AreaFlag.IN_FUNCTION);

--- a/src/main/java/org/byteskript/skript/lang/syntax/entry/EntryVerifySection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/entry/EntryVerifySection.java
@@ -97,5 +97,10 @@ public class EntryVerifySection extends Section {
     public boolean allowAsInputFor(Type type) {
         return false;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/conditional/ElseIfSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/conditional/ElseIfSection.java
@@ -7,6 +7,7 @@
 package org.byteskript.skript.lang.syntax.flow.conditional;
 
 import mx.kenzie.foundation.MethodBuilder;
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.WriteInstruction;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
@@ -45,7 +46,12 @@ public class ElseIfSection extends Section {
         if (!thing.startsWith("else if ")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void compile(Context context, Pattern.Match match) throws Throwable {
         if (!(context.getTree(context.getSection(1)) instanceof IfElseTree tree))

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/conditional/ElseSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/conditional/ElseSection.java
@@ -7,13 +7,11 @@
 package org.byteskript.skript.lang.syntax.flow.conditional;
 
 import mx.kenzie.foundation.MethodBuilder;
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
 import org.byteskript.skript.api.syntax.Section;
-import org.byteskript.skript.compiler.CompileState;
-import org.byteskript.skript.compiler.Context;
-import org.byteskript.skript.compiler.Pattern;
-import org.byteskript.skript.compiler.SkriptLangSpec;
+import org.byteskript.skript.compiler.*;
 import org.byteskript.skript.compiler.structure.IfElseTree;
 import org.byteskript.skript.compiler.structure.ProgrammaticSplitTree;
 import org.byteskript.skript.compiler.structure.SectionMeta;
@@ -47,7 +45,12 @@ public class ElseSection extends Section {
         if (!thing.equals("else")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void compile(Context context, Pattern.Match match) {
         if (!(context.getTree(context.getSection(1)) instanceof IfElseTree tree))

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/conditional/IfSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/conditional/IfSection.java
@@ -7,6 +7,7 @@
 package org.byteskript.skript.lang.syntax.flow.conditional;
 
 import mx.kenzie.foundation.MethodBuilder;
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.WriteInstruction;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
@@ -45,7 +46,12 @@ public class IfSection extends Section {
         if (!thing.startsWith("if ")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void compile(Context context, Pattern.Match match) throws Throwable {
         final IfElseTree tree = new IfElseTree(context.getSection(1), new MultiLabel());

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/error/CatchSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/error/CatchSection.java
@@ -6,6 +6,7 @@
 
 package org.byteskript.skript.lang.syntax.flow.error;
 
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
 import org.byteskript.skript.api.syntax.Section;
@@ -41,7 +42,12 @@ public class CatchSection extends Section {
         if (!thing.startsWith("catch ")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void preCompile(Context context, Pattern.Match match) throws Throwable {
         final ElementTree holder = context.getCompileCurrent().nested()[0];

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/error/TrySection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/error/TrySection.java
@@ -6,13 +6,11 @@
 
 package org.byteskript.skript.lang.syntax.flow.error;
 
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
 import org.byteskript.skript.api.syntax.Section;
-import org.byteskript.skript.compiler.CompileState;
-import org.byteskript.skript.compiler.Context;
-import org.byteskript.skript.compiler.Pattern;
-import org.byteskript.skript.compiler.SkriptLangSpec;
+import org.byteskript.skript.compiler.*;
 import org.byteskript.skript.compiler.structure.MultiLabel;
 import org.byteskript.skript.compiler.structure.SectionMeta;
 import org.byteskript.skript.compiler.structure.TryCatchTree;
@@ -43,7 +41,12 @@ public class TrySection extends Section {
         if (!thing.startsWith("try")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void compile(Context context, Pattern.Match match) throws Throwable {
         final TryCatchTree tree = new TryCatchTree(context.getSection(1), new MultiLabel());

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/execute/EffectMonitorSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/execute/EffectMonitorSection.java
@@ -6,13 +6,11 @@
 
 package org.byteskript.skript.lang.syntax.flow.execute;
 
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
 import org.byteskript.skript.api.syntax.Section;
-import org.byteskript.skript.compiler.CompileState;
-import org.byteskript.skript.compiler.Context;
-import org.byteskript.skript.compiler.Pattern;
-import org.byteskript.skript.compiler.SkriptLangSpec;
+import org.byteskript.skript.compiler.*;
 import org.byteskript.skript.compiler.structure.MonitorTree;
 import org.byteskript.skript.compiler.structure.ProgrammaticSplitTree;
 import org.byteskript.skript.compiler.structure.SectionMeta;
@@ -42,7 +40,12 @@ public class EffectMonitorSection extends Section {
         if (!thing.startsWith("monitor ")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void compile(Context context, Pattern.Match match) throws Throwable {
         final MonitorTree tree = new MonitorTree(context.getSection(1));

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/lambda/ExprLemmaSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/lambda/ExprLemmaSection.java
@@ -44,6 +44,11 @@ public class ExprLemmaSection extends ExtractedSection {
     public boolean allowAsInputFor(Type type) {
         return CommonTypes.OBJECT.equals(type) || CommonTypes.EXECUTABLE.equals(type);
     }
-    
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.EXECUTABLE;
+    }
+
+
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/loop/EffectLoopInSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/loop/EffectLoopInSection.java
@@ -7,6 +7,7 @@
 package org.byteskript.skript.lang.syntax.flow.loop;
 
 import mx.kenzie.foundation.MethodBuilder;
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.WriteInstruction;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
@@ -51,7 +52,12 @@ public class EffectLoopInSection extends Section {
         if (!thing.contains(" in ")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void preCompile(Context context, Pattern.Match match) throws Throwable {
         final ElementTree holder = context.getCompileCurrent().nested()[0];

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/loop/EffectLoopTimesSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/loop/EffectLoopTimesSection.java
@@ -7,6 +7,7 @@
 package org.byteskript.skript.lang.syntax.flow.loop;
 
 import mx.kenzie.foundation.MethodBuilder;
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.WriteInstruction;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
@@ -45,7 +46,12 @@ public class EffectLoopTimesSection extends Section {
         if (!thing.endsWith(" times")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void preCompile(Context context, Pattern.Match match) throws Throwable {
         final LoopTree tree = new LoopTree(context.getSection(1));

--- a/src/main/java/org/byteskript/skript/lang/syntax/flow/loop/EffectWhileSection.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/flow/loop/EffectWhileSection.java
@@ -7,14 +7,12 @@
 package org.byteskript.skript.lang.syntax.flow.loop;
 
 import mx.kenzie.foundation.MethodBuilder;
+import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.WriteInstruction;
 import mx.kenzie.foundation.compiler.State;
 import org.byteskript.skript.api.note.Documentation;
 import org.byteskript.skript.api.syntax.Section;
-import org.byteskript.skript.compiler.CompileState;
-import org.byteskript.skript.compiler.Context;
-import org.byteskript.skript.compiler.Pattern;
-import org.byteskript.skript.compiler.SkriptLangSpec;
+import org.byteskript.skript.compiler.*;
 import org.byteskript.skript.compiler.structure.ProgrammaticSplitTree;
 import org.byteskript.skript.compiler.structure.SectionMeta;
 import org.byteskript.skript.compiler.structure.WhileTree;
@@ -47,7 +45,12 @@ public class EffectWhileSection extends Section {
         if (!thing.startsWith("while ")) return null;
         return super.match(thing, context);
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
     @Override
     public void preCompile(Context context, Pattern.Match match) throws Throwable {
         final WhileTree tree = new WhileTree(context.getSection(1));

--- a/src/main/java/org/byteskript/skript/lang/syntax/function/ExprFunctionExternal.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/function/ExprFunctionExternal.java
@@ -105,7 +105,23 @@ public class ExprFunctionExternal extends SimpleExpression {
     @Override
     public void preCompile(Context context, Pattern.Match match) throws Throwable {
         final ElementTree[] trees = context.getCompileCurrent().nested();
-        for (final ElementTree tree : trees) tree.takeAtomic = true;
+        int ctr = 0;
+        for (final ElementTree tree : trees) {
+            tree.takeAtomic = true;
+            var type = tree.current().getReturnType();
+
+            /*
+             Probably safe to assume none of our inputs have a Void return type...
+             That being said, the return type for expressions can't always be trusted,
+             because some of them have incorrect return types (c.i.p. ExprCurrentScript).
+
+             This is going to break them as inputs into FunctionExternal, but those expressions
+             are already incredibly broken, so this has little effect on the overall functionality
+             of the language.
+            */
+            type = type.matches(Void.class) ? CommonTypes.OBJECT : type;
+            ((FunctionDetails)match.meta()).arguments[ctr++] = type;
+        }
         super.preCompile(context, match);
     }
     

--- a/src/main/java/org/byteskript/skript/lang/syntax/generic/ExprBracket.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/generic/ExprBracket.java
@@ -50,5 +50,10 @@ public class ExprBracket extends InnerModifyExpression {
     public boolean allowAsInputFor(Type type) {
         return true;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.OBJECT;
+    }
+
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/generic/ExprProperty.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/generic/ExprProperty.java
@@ -51,7 +51,12 @@ public class ExprProperty extends RelationalExpression implements Referent {
     public boolean allowAsInputFor(Type type) {
         return true;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.OBJECT;
+    }
+
     @Override
     public Pattern.Match match(String thing, Context context) {
         final int i;

--- a/src/main/java/org/byteskript/skript/lang/syntax/generic/ExprSystemInput.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/generic/ExprSystemInput.java
@@ -17,6 +17,7 @@ import org.byteskript.skript.compiler.SkriptLangSpec;
 import org.byteskript.skript.lang.element.StandardElements;
 import org.byteskript.skript.runtime.internal.ExtractedSyntaxCalls;
 
+import java.io.InputStream;
 import java.lang.reflect.Method;
 
 @Documentation(
@@ -48,7 +49,7 @@ public class ExprSystemInput extends SimpleExpression {
         return true;
     }
     
-    @Override
+    //@Override // not implemented yet
     public boolean requiresMainThread() {
         return true;
     }

--- a/src/main/java/org/byteskript/skript/lang/syntax/literal/BooleanLiteral.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/literal/BooleanLiteral.java
@@ -11,6 +11,7 @@ import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.WriteInstruction;
 import org.byteskript.skript.api.note.Documentation;
 import org.byteskript.skript.api.syntax.Literal;
+import org.byteskript.skript.compiler.CommonTypes;
 import org.byteskript.skript.compiler.Context;
 import org.byteskript.skript.compiler.Pattern;
 import org.byteskript.skript.compiler.SkriptLangSpec;
@@ -58,5 +59,10 @@ public class BooleanLiteral extends Literal<Boolean> {
     public boolean allowAsInputFor(Type type) {
         return true;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.BOOLEAN;
+    }
+
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/literal/DoubleLiteral.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/literal/DoubleLiteral.java
@@ -76,4 +76,9 @@ public class DoubleLiteral extends Literal<Double> {
     public boolean allowAsInputFor(Type type) {
         return CommonTypes.NUMBER.equals(type) || CommonTypes.OBJECT.equals(type);
     }
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.DOUBLE;
+    }
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/literal/FloatLiteral.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/literal/FloatLiteral.java
@@ -75,4 +75,9 @@ public class FloatLiteral extends Literal<Float> {
     public boolean allowAsInputFor(Type type) {
         return CommonTypes.NUMBER.equals(type) || CommonTypes.OBJECT.equals(type);
     }
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.FLOAT;
+    }
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/literal/IntegerLiteral.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/literal/IntegerLiteral.java
@@ -74,7 +74,12 @@ public class IntegerLiteral extends Literal<Integer> {
         if (matcher.find()) return new Pattern.Match(matcher, thing);
         return null;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.INTEGER;
+    }
+
     @Override
     public boolean allowAsInputFor(Type type) {
         return CommonTypes.INTEGER.equals(type) || CommonTypes.NUMBER.equals(type) || CommonTypes.OBJECT.equals(type);

--- a/src/main/java/org/byteskript/skript/lang/syntax/literal/LongLiteral.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/literal/LongLiteral.java
@@ -76,4 +76,9 @@ public class LongLiteral extends Literal<Long> {
     public boolean allowAsInputFor(Type type) {
         return CommonTypes.NUMBER.equals(type) || CommonTypes.OBJECT.equals(type);
     }
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.LONG;
+    }
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/literal/NoneLiteral.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/literal/NoneLiteral.java
@@ -11,6 +11,7 @@ import mx.kenzie.foundation.Type;
 import mx.kenzie.foundation.WriteInstruction;
 import org.byteskript.skript.api.note.Documentation;
 import org.byteskript.skript.api.syntax.Literal;
+import org.byteskript.skript.compiler.CommonTypes;
 import org.byteskript.skript.compiler.Context;
 import org.byteskript.skript.compiler.Pattern;
 import org.byteskript.skript.compiler.SkriptLangSpec;
@@ -56,5 +57,10 @@ public class NoneLiteral extends Literal<Void> {
     public boolean allowAsInputFor(Type type) {
         return true;
     }
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.VOID;
+    }
+
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/literal/RegexLiteral.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/literal/RegexLiteral.java
@@ -71,6 +71,6 @@ public class RegexLiteral extends Literal<java.util.regex.Pattern> {
     
     @Override
     public Type getReturnType() {
-        return CommonTypes.STRING;
+        return new Type(java.util.regex.Pattern.class);
     }
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/map/ExprKeyInMap.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/map/ExprKeyInMap.java
@@ -71,6 +71,11 @@ public class ExprKeyInMap extends RelationalExpression implements Referent {
     public boolean allowAsInputFor(Type type) {
         return super.allowAsInputFor(type) || CommonTypes.REFERENT.equals(type);
     }
-    
-    
+
+    @Override
+    public Type getReturnType() {
+        return CommonTypes.OBJECT;
+    }
+
+
 }

--- a/src/main/java/org/byteskript/skript/lang/syntax/script/ExprCompiler.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/script/ExprCompiler.java
@@ -14,6 +14,7 @@ import org.byteskript.skript.compiler.SkriptLangSpec;
 import org.byteskript.skript.lang.element.StandardElements;
 import org.byteskript.skript.lang.handler.StandardHandlers;
 import org.byteskript.skript.runtime.internal.ExtractedSyntaxCalls;
+import org.byteskript.skript.runtime.internal.ModifiableCompiler;
 
 @Documentation(
     name = "Compiler",
@@ -39,7 +40,7 @@ public class ExprCompiler extends SimpleExpression {
     
     @Override
     public Type getReturnType() {
-        return CommonTypes.OBJECT;
+        return new Type(ModifiableCompiler.class);
     }
     
     @Override

--- a/src/main/java/org/byteskript/skript/lang/syntax/script/ExprCurrentScript.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/script/ExprCurrentScript.java
@@ -16,6 +16,7 @@ import org.byteskript.skript.compiler.Context;
 import org.byteskript.skript.compiler.Pattern;
 import org.byteskript.skript.compiler.SkriptLangSpec;
 import org.byteskript.skript.lang.element.StandardElements;
+import org.byteskript.skript.runtime.Script;
 
 @Documentation(
     name = "Current Script",
@@ -37,7 +38,7 @@ public class ExprCurrentScript extends SimpleExpression {
     
     @Override
     public Type getReturnType() {
-        return CommonTypes.STRING;
+        return new Type(Script.class);
     }
     
     @Override

--- a/src/main/java/org/byteskript/skript/lang/syntax/type/ExprThisThing.java
+++ b/src/main/java/org/byteskript/skript/lang/syntax/type/ExprThisThing.java
@@ -35,7 +35,7 @@ public class ExprThisThing extends SimpleExpression {
     
     @Override
     public Type getReturnType() {
-        return CommonTypes.STRING;
+        return CommonTypes.OBJECT;
     }
     
     @Override


### PR DESCRIPTION
This pull request fixes several issues related to unimplemented or incorrect code:
- It makes providing a return type for syntax elements mandatory
- It adds return type definitions to existing syntax, and fixes incorrect ones
- It temporarily removes `requiresMainThread`, which is currently not implemented
- It allows ExprFunctionExternal to retain type information from pre-compile time to better differentiate between methods of the same name with different parameter types
