### PR TITLE
Don't throw unchecked exception in unsafe.set_java_field

### DIFF
--- a/src/main/java/unsafe.java
+++ b/src/main/java/unsafe.java
@@ -119,10 +119,6 @@ public class unsafe extends UnsafeAccessor {
         final FieldAccessor<?> accessor = mirror(owner).field((name) + "");
         if (accessor != null) {
             accessor.set((value));
-        } else {
-            throw new IllegalArgumentException(
-                    "Tried to set field " + owner.getClass().getSimpleName()
-                            + "#" + name + ", but it does not exist");
         }
     }
     //endregion

--- a/src/main/java/unsafe.java
+++ b/src/main/java/unsafe.java
@@ -116,7 +116,14 @@ public class unsafe extends UnsafeAccessor {
     }
     
     public static void set_java_field(Object owner, Object name, Object value) {
-        mirror(owner).field((name) + "").set((value));
+        final FieldAccessor<?> accessor = mirror(owner).field((name) + "");
+        if (accessor != null) {
+            accessor.set((value));
+        } else {
+            throw new IllegalArgumentException(
+                    "Tried to set field " + owner.getClass().getSimpleName()
+                            + "#" + name + ", but it does not exist");
+        }
     }
     //endregion
     


### PR DESCRIPTION
This pull request modifies `unsafe.set_java_field(Object, Object, Object)` such that, instead of throwing an unchecked exception, it simply does not set a field if the field does not exist. This corresponds with other `unsafe` methods (namely `get_java_field`), which do not throw exceptions if the target does not exist.