### PR TITLE
Newline fixes to compiler debug logs

### DIFF
--- a/src/main/java/org/byteskript/skript/compiler/DebugSkriptCompiler.java
+++ b/src/main/java/org/byteskript/skript/compiler/DebugSkriptCompiler.java
@@ -41,15 +41,15 @@ public class DebugSkriptCompiler extends SimpleSkriptCompiler {
     public PostCompileClass[] compile(InputStream stream, Type path) {
         this.stream.print("\n");
         this.stream.print("--" + path.internalName());
-        this.stream.print("\n");
+        this.stream.print("\n\n");
         return super.compile(stream, path);
     }
     
     @Override
     public PostCompileClass[] compile(String source, Type path) {
-        this.stream.print("\n\n");
-        this.stream.print("--" + path.internalName());
         this.stream.print("\n");
+        this.stream.print("--" + path.internalName());
+        this.stream.print("\n\n");
         return super.compile(source, path);
     }
     
@@ -59,9 +59,8 @@ public class DebugSkriptCompiler extends SimpleSkriptCompiler {
     }
     
     protected void debug(ElementTree tree, FileContext context) {
-        this.stream.print("\n");
         for (int i = 0; i < context.lineIndent; i++) this.stream.print("\t");
-        this.stream.print(tree.toString(context));
+        this.stream.println(tree.toString(context));
     }
     
 }

--- a/src/test/java/org/byteskript/skript/test/SyntaxTreeTest.java
+++ b/src/test/java/org/byteskript/skript/test/SyntaxTreeTest.java
@@ -47,7 +47,6 @@ public class SyntaxTreeTest extends SkriptTest {
             """, new Type("test"));
         assert stream.toString().equals("""
             
-            
             --test
             
             MemberDictionary():
@@ -68,7 +67,8 @@ public class SyntaxTreeTest extends SkriptTest {
               
             EventLoad():
             	EntryTriggerSection():
-            		EffectPrint(StringLiteral("Foo"))""") : '"' + stream.toString() + '"';
+            		EffectPrint(StringLiteral("Foo"))
+            """) : '"' + stream.toString() + '"';
     }
     
 }


### PR DESCRIPTION
This PR fixes a small quirk of the compiler debug information where the last line of debug output would not be followed by a newline character.
